### PR TITLE
Follow the IOExpander_Base pull API of M5Unified 0.2.21

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/M5Stack/M5StamPLC.git"
     },
     "dependencies": {
-        "M5Unified": "*",
+        "M5Unified": ">=0.2.21",
         "M5GFX": "*"
     },
     "version": "1.2.0",

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Device Control
 url=https://github.com/m5stack/M5StamPLC.git
 architectures=esp32
 includes=src,src/utils
-depends=M5Unified
+depends=M5Unified (>=0.2.21)

--- a/src/M5StamPLC.cpp
+++ b/src/M5StamPLC.cpp
@@ -61,15 +61,15 @@ void M5_STAMPLC::io_expander_a_init()
 
     // Status light init
     ioe.setDirection(4, true);
-    ioe.setPullMode(4, false);
+    ioe.setPullMode(4, m5::IOExpander_Base::pull_down);
     ioe.setHighImpedance(4, true);
 
     ioe.setDirection(5, true);
-    ioe.setPullMode(5, false);
+    ioe.setPullMode(5, m5::IOExpander_Base::pull_down);
     ioe.setHighImpedance(5, true);
 
     ioe.setDirection(6, true);
-    ioe.setPullMode(6, false);
+    ioe.setPullMode(6, m5::IOExpander_Base::pull_down);
     ioe.setHighImpedance(6, true);
 
     ioe.resetIrq();

--- a/src/modules/M5StamPLC_AC.cpp
+++ b/src/modules/M5StamPLC_AC.cpp
@@ -32,13 +32,13 @@ bool M5StamPLC_AC::begin()
 
     // AC relay
     _ioe->setDirection(_pin_relay, true);
-    _ioe->setPullMode(_pin_relay, false);
+    _ioe->setPullMode(_pin_relay, m5::IOExpander_Base::pull_down);
     _ioe->setHighImpedance(_pin_relay, false);
 
     // Status light
     auto setup_status_light_pin = [](m5::PI4IOE5V6408_Class* ioe, uint8_t pin) {
         ioe->setDirection(pin, true);
-        ioe->setPullMode(pin, true);
+        ioe->setPullMode(pin, m5::IOExpander_Base::pull_up);
         ioe->setHighImpedance(pin, false);
         ioe->digitalWrite(pin, true);
     };


### PR DESCRIPTION
## Problem

M5Unified 0.2.21 changed the `IOExpander_Base` pull API: `setPullMode(pin, bool)` and `enablePull(pin, bool)` were replaced by `setPullMode(pin, gpio_pull_t)` (`pull_none` / `pull_up` / `pull_down`). M5StamPLC 1.2.0 calls the old form in five places, so it no longer compiles against the current M5Unified release:

```
src/M5StamPLC.cpp:64:24: error: cannot convert 'bool' to 'm5::IOExpander_Base::gpio_pull_t'
src/modules/M5StamPLC_AC.cpp:35:35: error: cannot convert 'bool' to 'm5::IOExpander_Base::gpio_pull_t'
...
```

(Same class of problem as m5stack/StackChan-BSP#12 for StackChan-BSP.)

## Change

- Call the new API directly: `setPullMode(pin, false)` → `pull_down`, `setPullMode(pin, true)` → `pull_up`.
- Declare the requirement in the library metadata: `depends=M5Unified (>=0.2.21)` in `library.properties` and `"M5Unified": ">=0.2.21"` in `library.json`, so the Library Manager and PlatformIO install a matching M5Unified instead of failing at compile time.

The register state is unchanged: the old bool form only wrote the PI4IOE5V6408 pull-select register (0x0D) and relied on the pull-enable register (0x0B) being at its reset default (all enabled) during init; `pull_up` / `pull_down` write the same select bit and set the enable bit that was already set. `M5.begin()` does not touch the pull state of pins 4–6 before `io_expander_a_init()`, and the AC module's expander is freshly constructed.

## Verification

Compiled a sketch calling `M5StamPLC.begin()` with PlatformIO (pioarduino 55.03.34, `m5stack-stamps3`, Arduino) against M5Unified 0.2.21 (develop) + M5GFX 0.2.28: fails on the unmodified library with the errors above, builds with this change. `clang-format --dry-run` reports no differences for the touched files.

## Note on the `Build Examples` workflow

It cannot validate this change at the moment: with the current `m5stack:esp32` "latest" core (esp32s3-libs 3.3.9) every example already fails on `main` in the SDK's esp-modbus header (`mb_port_types.h:118: ISO C++ forbids declaration of '_Atomic'`), reached through `M5StamPLC.h` → `mbcontroller.h`, before any library code is compiled (the last green run used esp32s3-libs 3.3.7). I reproduced that on my fork for both `main` and this branch (identical failure). That is a core/SDK problem independent of this PR; pinning the core version in the workflow would be a separate change. `clang-format Check` passes on this branch.
